### PR TITLE
Asset Manager Framework 0.10.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,6 @@
 	],
 	"require": {
 		"php": ">=7.2",
-		"humanmade/asset-manager-framework": "~0.6"
+		"humanmade/asset-manager-framework": "~0.10"
 	}
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -8,7 +8,7 @@ use WP_Scripts;
  * Bootstrap function.
  */
 function bootstrap() : void {
-	add_filter( 'amf/provider_class', __NAMESPACE__ . '\\get_provider' );
+	add_filter( 'amf/provider', __NAMESPACE__ . '\\get_provider' );
 	add_action( 'amf/inserted_attachment', __NAMESPACE__ . '\\track_download', 10, 3 );
 	add_action( 'wp_default_scripts', __NAMESPACE__ . '\\override_per_page', 100 );
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\\register_key_setting' );
@@ -18,12 +18,12 @@ function bootstrap() : void {
 /**
  * Get the provider for AMF.
  *
- * @return string
+ * @return Provider
  */
-function get_provider() : string {
+function get_provider() : Provider {
 	require_once __DIR__ . '/class-provider.php';
 
-	return Provider::class;
+	return new Provider();
 }
 
 /**


### PR DESCRIPTION
This PR updates the Asset Manager Framework package to the [current version `0.10.0`](https://github.com/humanmade/asset-manager-framework/releases/tag/0.10.0). This release includes some **breaking changes**, which this PR addresses.