### PR TITLE
Adds missing 'meta' key to prevent PHP error

### DIFF
--- a/inc/class-provider.php
+++ b/inc/class-provider.php
@@ -216,6 +216,9 @@ class Provider extends BaseProvider implements Resize {
 		);
 		$item->set_description( $description );
 		$item->set_caption( $description );
+		$item->set_meta([
+		    'unsplash_id' => $image->id
+		]);
 
 		// Generate sizes.
 		$sizes = $this->get_image_sizes( $image );

--- a/inc/class-provider.php
+++ b/inc/class-provider.php
@@ -216,9 +216,9 @@ class Provider extends BaseProvider implements Resize {
 		);
 		$item->set_description( $description );
 		$item->set_caption( $description );
-		$item->set_meta([
-		    'unsplash_id' => $image->id
-		]);
+		$item->set_meta( [
+			'unsplash_id' => $image->id,
+		] );
 
 		// Generate sizes.
 		$sizes = $this->get_image_sizes( $image );


### PR DESCRIPTION
Inserting an image from Unsplash throws an PHP error as the index `$selection['meta']` is not available here: https://github.com/humanmade/asset-manager-framework/blob/c6167cd7b3087b4c8c37831e98827eb48f6ad1d4/inc/namespace.php#L157